### PR TITLE
Fix Travis: build the datastructures package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ env:
   global:
     - GAPROOT=gaproot
     - COVDIR=coverage
-    - GAP_PKGS_TO_BUILD="io profiling orb digraphs grape"
+    - GAP_PKGS_TO_BUILD="io profiling orb digraphs grape datastructures"
 
 addons:
   apt_packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,6 @@ matrix:
       compiler: gcc
     - env: ABI=32
 
-branches:
-  only:
-    - master
-
 before_script:
   - export GAPROOT="$HOME/gap"
   - git clone https://github.com/gap-system/pkg-ci-scripts.git scripts


### PR DESCRIPTION
Travis wasn't working, because OrbitalGraphs couldn't load, because Digraphs couldn't load, because the datastructures package wasn't built. Now we build it. I also added in that Travis will check builds pushed to all branches, not just master.