### PR TITLE
Simplify .travis.yml and test stable GAP branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,22 @@
 language: c
 env:
   global:
-    - GAPROOT=gaproot
-    - COVDIR=coverage
     - GAP_PKGS_TO_BUILD="io profiling orb digraphs grape datastructures"
 
 addons:
   apt_packages:
     - libgmp-dev
     - libreadline-dev
-    - libgmp-dev:i386
-    - libreadline-dev:i386
-    - gcc-multilib
-    - g++-multilib
+    - zlib1g-dev
 
 matrix:
   include:
-    - env: CFLAGS="-O2" CC=clang CXX=clang++
-      compiler: clang
-    - env: CFLAGS="-O2"
-      compiler: gcc
-    - env: ABI=32
+    - env: GAPBRANCH=master
+    - env: GAPBRANCH=stable-4.11
+    - env: GAPBRANCH=stable-4.10
+    - env: GAPBRANCH=stable-4.9
 
 before_script:
-  - export GAPROOT="$HOME/gap"
   - git clone https://github.com/gap-system/pkg-ci-scripts.git scripts
   - scripts/build_gap.sh
 script:


### PR DESCRIPTION
Since OrbitalGraphs is a simple package that doesn't involve any compilation, I don't think there's much need to test the package with GAP under different compilation options.

However, I do think it's a nice idea to test against older versions of GAP, to check how the package is getting on with backwards compatibility.