### PR TITLE
fix badge to show GitHubActions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/gap-packages/OrbitalGraphs.svg?branch=master)](https://travis-ci.org/gap-packages/OrbitalGraphs)
+[![Build Status](https://github.com/gap-packages/OrbitalGraphs/workflows/CI/badge.svg)](https://github.com/gap-packages/OrbitalGraphs/actions?query=workflow%3ACI+branch%3Amaster)
 [![Code Coverage](https://codecov.io/github/gap-packages/OrbitalGraphs/coverage.svg?branch=master&token=)](https://codecov.io/gh/gap-packages/OrbitalGraphs)
 
 # OrbitalGraphs
@@ -10,4 +10,3 @@ If you want to experiment with the code, use the binder link below.
 
 
 [![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/gap-packages/OrbitalGraphs/master)
-


### PR DESCRIPTION
Moving from travis to GitHubActions broke the nice link in the README. This should be fixed now.