### PR TITLE
Add the attribute `DotOrbitalGraph` to enable visualising orbital graphs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   # The CI test job
   test:
-    name: ${{ matrix.gap-branch }}
+    name: GAP ${{ matrix.gap-branch }} ${{ matrix.name }}
     runs-on: ubuntu-latest
     # Don't run this twice on PRs for branches pushed to the same repository
     if: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) }}
@@ -18,12 +18,19 @@ jobs:
         gap-branch:
           - master
           - stable-4.11
+        pkgs-to-clone:
+          - ""
+        include:
+          - name: "/ Digraphs master"
+            gap-branch: master
+            pkgs-to-clone: "digraphs/digraphs"
 
     steps:
       - uses: actions/checkout@v2
       - uses: gap-actions/setup-gap@v2
         with:
           GAPBRANCH: ${{ matrix.gap-branch }}
+          GAP_PKGS_TO_CLONE: ${{ matrix.pkgs-to-clone }}
           GAP_PKGS_TO_BUILD: "io profiling orb digraphs grape datastructures"
       - uses: gap-actions/build-pkg@v1
       - uses: gap-actions/run-pkg-tests@v2

--- a/gap/display.gd
+++ b/gap/display.gd
@@ -1,0 +1,46 @@
+# OrbitalGraphs: Computations with orbital graphs in GAP
+# A GAP package by Paula Hähndel, Markus Pfeiffer, and Wilf A. Wilson.
+#
+# SPDX-License-Identifier: MPL-2.0
+#
+# Declarations
+
+#! @Chapter Visualising orbital graphs
+
+#! @Section Visualing an orbital graph via the DOT format
+
+#! @Arguments D
+#! @Returns A string
+#! @Description
+#! <B>Warning:</B> This function requires version 1.4.0 of the Digraphs package,
+#! or newer.
+#!
+#! Given an orbital graph <A>D</A>, this function returns a string
+#! that contains a description of <A>D</A> in DOT format.
+#!
+#! The edge of <A>D</A> corresponding to its
+#! <Ref Attr="BasePair" Label="for IsOrbitalGraph"/>
+#! is coloured red, while the remaining edges are coloured black.
+#!
+#! The DOT string for <A>D</A> can then be compiled and displayed with the
+#! <Ref Func="Splash" BookName="Digraphs"/> function of the Digraphs package.
+#!
+#! See <URL>https://en.wikipedia.org/wiki/DOT_(graph_description_language)</URL>
+#! for more information about this format.
+#! @BeginLogSession
+#! gap> G := Group([(1,2,3)]);;
+#! gap> o := OrbitalGraphs(G);;
+#! gap> Print(DotOrbitalGraph(o[1]));
+#! //dot
+#! digraph hgn{
+#! node [shape=circle]
+#! 1 [label="1"]
+#! 2 [label="2"]
+#! 3 [label="3"]
+#! 1 -> 2 [color=red]
+#! 2 -> 3
+#! 3 -> 1
+#! }
+#! gap> Splash(DotOrbitalGraph(o[1])); # To visualise
+#! @EndLogSession
+DeclareAttribute("DotOrbitalGraph", IsOrbitalGraph);

--- a/gap/display.gi
+++ b/gap/display.gi
@@ -1,0 +1,37 @@
+# OrbitalGraphs: Computations with orbital graphs in GAP
+# A GAP package by Paula Hähndel, Markus Pfeiffer, and Wilf A. Wilson.
+#
+# SPDX-License-Identifier: MPL-2.0
+#
+# Implementations
+
+if not IsBound(DIGRAPHS_DotDigraph) then
+    BindGlobal("DIGRAPHS_DotDigraph", function(arg...)
+        ErrorNoReturn("DotOrbitalGraph requires Digraphs v1.4.0 or newer");
+    end);
+    BindGlobal("DIGRAPHS_DotSymmetricDigraph", DIGRAPHS_DotDigraph);
+fi;
+
+InstallMethod(DotOrbitalGraph, "for an orbital graph", [IsOrbitalGraph],
+function(D)
+    local func, pair, vfunc, efunc, out;
+    
+    if IsSelfPaired(D) and not DigraphHasLoops(D) then
+        func := DIGRAPHS_DotSymmetricDigraph;
+        pair := Set(BasePair(D));
+    else
+        func := DIGRAPHS_DotDigraph;
+        pair := BasePair(D);
+    fi;
+
+    out := OutNeighbours(D);
+    vfunc := i -> StringFormatted(" [label=\"{}\"]", DigraphVertexLabel(D, i));
+    efunc := function(i, j)
+        if pair[1] = i and pair[2] = out[i][j] then
+            return " [color=red]";
+        fi;
+        return "";
+    end;
+
+    return func(D, [vfunc], [efunc]);
+end);

--- a/init.g
+++ b/init.g
@@ -6,3 +6,4 @@
 # Reading the declaration part of the package.
 
 ReadPackage("OrbitalGraphs", "gap/OrbitalGraphs.gd");
+ReadPackage("OrbitalGraphs", "gap/display.gd");

--- a/read.g
+++ b/read.g
@@ -6,5 +6,5 @@
 # Reading the implementation part of the package.
 
 ReadPackage("OrbitalGraphs", "gap/OrbitalGraphs.gi");
+ReadPackage("OrbitalGraphs", "gap/display.gi");
 ReadPackage("OrbitalGraphs", "gap/util.g");
-

--- a/tst/display.tst
+++ b/tst/display.tst
@@ -1,0 +1,42 @@
+#
+gap> START_TEST("OrbitalGraphs package: display.tst");
+gap> LoadPackage("orbitalgraphs", false);;
+
+# DotOrbitalGraph
+gap> G := Group((1,2,3,4));;
+gap> o := OrbitalGraphs(G);;
+gap> List(o, BasePair);
+[ [ 1, 2 ], [ 1, 3 ], [ 1, 4 ] ]
+#@if IsPackageLoaded("digraphs", "1.4.0")
+gap> Print(DotOrbitalGraph(o[1]));
+//dot
+digraph hgn{
+node [shape=circle]
+1 [label="1"]
+2 [label="2"]
+3 [label="3"]
+4 [label="4"]
+1 -> 2 [color=red]
+2 -> 3
+3 -> 4
+4 -> 1
+}
+gap> Print(DotOrbitalGraph(o[2]));
+//dot
+graph hgn{
+node [shape=circle]
+
+1 [label="1"]
+2 [label="2"]
+3 [label="3"]
+4 [label="4"]
+1 -- 3 [color=red]
+2 -- 4
+}
+#@else
+gap> DotOrbitalGraph(o[1]);
+Error, DotOrbitalGraph requires Digraphs v1.4.0 or newer
+#@fi
+
+#
+gap> STOP_TEST("OrbitalGraphs package: display.tst", 0);


### PR DESCRIPTION
`DotOrbitalGraph` produces a 'dot' string, which can be used to visualise an orbital graph. The vertices are labelled according to `DigraphVertexLabels` (which for now are just `[1..n]`), the arcs are directed or undirected according to the value of `IsSelfPaired`, and the arc corresponding to the base-pair is drawn in red, while all the other arcs are drawn in black.

This addresses the request from @markuspf https://github.com/gap-packages/OrbitalGraphs/issues/1#issue-346532363:
> when drawing an orbital graph, we could highlight the base-pair

This still needs documentation and tests. My implementation requires Digraphs v1.4.0, but I don't think we're ready to require that version yet, so it just gives an error if the installed Digraphs is too old.

TODO: Add a version CI test that actually uses the minimum required packages, so that I can test this code.

Closes #1.