### PR TITLE
Merge `OrbitalGraphs` with `_BTKit.getOrbitalList` so that BacktrackKit can use OrbitalGraphs

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "OrbitalGraphs",
 Subtitle := "Computations with orbital graphs in GAP",
-Version := "0.1.2",
+Version := "0.2.0",
 Date := "01/02/2022", # dd/mm/yyyy format
 License := "MPL-2.0",
 

--- a/gap/OrbitalGraphs.gd
+++ b/gap/OrbitalGraphs.gd
@@ -67,9 +67,9 @@ DeclareOperation("OrbitalGraphs", [IsPermGroup, IsHomogeneousList]);
 #! gap> D8 := Group([ (1,2,3,4), (2,4) ]);; StructureDescription(D8);
 #! "D8"
 #! gap> OrbitalGraphs(D8);
-#! [ <self-paired orbital graph of D8 on 4 vertices with base-pair (1,3), 4 arcs>
+#! [ <self-paired orbital graph of D8 on 4 vertices with base-pair (1,2), 8 arcs>
 #!     , <self-paired orbital graph of D8 on 4 vertices 
-#!     with base-pair (1,2), 8 arcs> ]
+#!     with base-pair (1,3), 4 arcs> ]
 #! @EndExampleSession
 DeclareOperation("OrbitalGraphs", [IsPermGroup, IsInt]);
 

--- a/tst/orbitalgraphs01.tst
+++ b/tst/orbitalgraphs01.tst
@@ -14,9 +14,9 @@ gap> START_TEST("orbitalgraphs01.tst");
 gap> D8 := Group([ (1,2,3,4), (2,4) ]);; StructureDescription(D8);
 "D8"
 gap> OrbitalGraphs(D8);
-[ <self-paired orbital graph of D8 on 4 vertices with base-pair (1,3), 4 arcs>
+[ <self-paired orbital graph of D8 on 4 vertices with base-pair (1,2), 8 arcs>
     , <self-paired orbital graph of D8 on 4 vertices 
-    with base-pair (1,2), 8 arcs> ]
+    with base-pair (1,3), 4 arcs> ]
 
 # doc/_Chapter_Orbital_graphs.xml:101-114
 gap> D8 := DihedralGroup(IsPermGroup, 8);

--- a/tst/orbitals.tst
+++ b/tst/orbitals.tst
@@ -27,9 +27,9 @@ gap> Length(orbitals);
 gap> ForAll(orbitals, D -> IsDigraph(D) and DigraphNrVertices(D) = 114);
 true
 gap> List(orbitals, DigraphNrEdges);
-[ 2, 2, 2, 2, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 8, 8, 8, 8, 8, 8, 8, 8, 
-  8, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 
-  100, 100, 200, 200, 200, 200, 2450, 2450, 2500, 2500 ]
+[ 2450, 100, 100, 2500, 100, 100, 200, 100, 2, 4, 100, 4, 4, 8, 100, 4, 2, 
+  100, 4, 4, 8, 2500, 100, 100, 2450, 100, 100, 200, 100, 4, 4, 100, 2, 4, 8, 
+  100, 4, 4, 100, 4, 2, 8, 200, 8, 8, 200, 8, 8, 8, 4 ]
 gap> Number(orbitals, IsSymmetricDigraph);
 8
 gap> Set(orbitals, x -> Minimum(DigraphEdges(x)));
@@ -105,6 +105,29 @@ gap> DigraphEdges(x);
 gap> OrbitalGraphs(G) =
 >   List(OrbitalGraphs(G),
 >        x -> OrbitalGraph(G, BasePair(x), LargestMovedPoint(G)));
+true
+
+# OrbitalGraphs: `skipone` option
+gap> IsEmpty(OrbitalGraphs(SymmetricGroup(5) : skipone));
+true
+gap> Length(OrbitalGraphs(Group((1,2,3,4))));
+3
+gap> Length(OrbitalGraphs(Group((1,2,3,4)) : skipone));
+2
+
+# OrbitalGraphs: `cutoff` option
+gap> Length(OrbitalGraphs(DihedralGroup(IsPermGroup, 8)));
+2
+gap> Length(OrbitalGraphs(DihedralGroup(IsPermGroup, 8) : cutoff := 4));
+1
+
+# OrbitalGraphs: `search` option
+gap> IsEmpty(OrbitalGraphs(PSL(2, 5) : search));
+true
+gap> G := Group([ (1,4)(2,3), (2,3)(5,6) ]);;
+gap> Length(OrbitalGraphs(G, 6));
+9
+gap> IsEmpty(OrbitalGraphs(G, 6 : search));
 true
 
 #


### PR DESCRIPTION
This is also pretty much merged `OrbitalGraphs` with ferret's `_YAPB_getOrbitalList`. Perhaps we will also eventually get ferret to use `OrbitalGraphs`, too.

This is some progress towards #40.